### PR TITLE
[feat] use aiohttp flags to enable chunks for using compressions

### DIFF
--- a/aiohttp_s3_client/client.py
+++ b/aiohttp_s3_client/client.py
@@ -89,7 +89,7 @@ class S3Client:
         if data_length:
             headers[hdrs.CONTENT_LENGTH] = str(data_length)
         elif data is not None:
-            headers[hdrs.CONTENT_ENCODING] = "chunked"
+            kwargs["chunked"] = True
 
         if data is not None and content_sha256 is None:
             content_sha256 = UNSIGNED_PAYLOAD

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,8 +1,6 @@
-import gzip
 import os
 import sys
 from http import HTTPStatus
-from io import BytesIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Iterable
@@ -16,7 +14,7 @@ from aiohttp_s3_client import S3Client
 
 @pytest.fixture()
 async def s3_url() -> URL:
-    return URL("http://user:hackme@localhost:9000/")
+    return URL(os.getenv("S3_URL"))
 
 
 @pytest.fixture

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,12 +1,14 @@
+import gzip
 import os
 import sys
 from http import HTTPStatus
+from io import BytesIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Iterable
 
 import pytest
-from aiohttp import ClientSession
+from aiohttp import ClientSession, hdrs
 from yarl import URL
 
 from aiohttp_s3_client import S3Client
@@ -14,7 +16,7 @@ from aiohttp_s3_client import S3Client
 
 @pytest.fixture()
 async def s3_url() -> URL:
-    return URL(os.getenv("S3_URL"))
+    return URL("http://user:hackme@localhost:9000/")
 
 
 @pytest.fixture
@@ -93,4 +95,22 @@ async def test_url_path_with_colon(s3_url: URL, s3_client: S3Client):
 
     async with s3_client.get(key) as response:
         result = await response.read()
+        assert result == data
+
+
+@pytest.mark.parametrize("object_name", ("test/test", "/test/test"))
+async def test_put_compression(s3_url: URL, s3_client: S3Client, object_name):
+    async def async_iterable(iterable: Iterable[bytes]):
+        for i in iterable:  # type: int
+            yield i.to_bytes(1, sys.byteorder)
+
+    data = b"hello, world"
+    async with s3_client.put(
+        object_name, async_iterable(data), compress="gzip",
+    ) as response:
+        assert response.status == HTTPStatus.OK
+
+    async with s3_client.get(object_name) as response:
+        result = await response.read()
+        assert response.headers[hdrs.CONTENT_ENCODING] == "gzip"
         assert result == data


### PR DESCRIPTION
Enable chunks via aiohttp args to unlock another features (e.g. compressions)